### PR TITLE
Update to 0.3-2, zeromq 4.2.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3-1" %}
+{% set version = "0.3-2" %}
 
 package:
   name: r-pbdzmq
@@ -9,7 +9,7 @@ source:
   url:
     - http://cran.r-project.org/src/contrib/pbdZMQ_{{ version }}.tar.gz
     - http://cran.r-project.org/src/contrib/Archive/pbdZMQ/pbdZMQ_{{ version }}.tar.gz
-  sha256: e82039ca02c6275298d0099317d7c9a3c628d7f6954c24298b954718b00b5b13
+  sha256: ece2a2881c662f77126e4801ba4e01c991331842b0d636ce5a2b591b9de3fc37
 
 build:
   number: 0
@@ -30,11 +30,11 @@ requirements:  # [not win32]
     - pkg-config  # [not win]
     - m2w64-toolchain  # [win64]
     - gcc  # [not win]
-    - zeromq 4.1.*  # [not win]
+    - zeromq 4.2.*  # [not win]
   run:  # [not win32]
     - r-base  # [not win32]
     - r-r6  # [not win32]
-    - zeromq 4.1.*  # [not win]
+    - zeromq 4.2.*  # [not win]
 
 test:
   commands:


### PR DESCRIPTION
I think the zeromq 4.1.* pinning in this package is leading to
https://github.com/jupyter/docker-stacks/issues/589 when installing
IRkernel. The package appears to build OK with zeromq 4.2.* instead
which should allow pyzeromq 17.*.

I don't know the ramifications of changing the zeromq minimum version
here, so feel free to correct me if there's a better way or other work to be done.