### PR TITLE
Updated zeromq to version 4.2.*

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,11 +30,11 @@ requirements:  # [not win32]
     - pkg-config  # [not win]
     - m2w64-toolchain  # [win64]
     - gcc  # [not win]
-    - zeromq 4.1.*  # [not win]
+    - zeromq 4.2.*  # [not win]
   run:  # [not win32]
     - r-base  # [not win32]
     - r-r6  # [not win32]
-    - zeromq 4.1.*  # [not win]
+    - zeromq 4.2.*  # [not win]
 
 test:
   commands:


### PR DESCRIPTION
Latest version for https://anaconda.org/anaconda/zeromq is 4.2.3, pinning dependency to older version is causing issues in using latest version of pyzmq https://github.com/zeromq/pyzmq/tree/v17.0.0 which need latest version of zeromq.
We are unable to use it from within our Jupyter environment.
Steps to reproduce problem:
conda install notebook
conda install r-essentials
The following packages will be DOWNGRADED:
pyzmq: 17.0.0-py36_3 conda-forge --> 16.0.2-py36_0 defaults
zeromq: 4.2.3-2 conda-forge --> 4.1.5-0 conda-forge
This downgrading of zeromq leads to downgrading of pyzmq and produces an error with latest version of Tornado which is 5.0.1

I have added more info about my environment and command that I am using to upgrade in comments. Please let me know if anything else is required.